### PR TITLE
[ODSG-30] Add permission to assign roles and ensure Admins can do that

### DIFF
--- a/config/user.role.administrator.yml
+++ b/config/user.role.administrator.yml
@@ -10,4 +10,5 @@ permissions:
   - 'access toolbar'
   - 'access user profiles'
   - 'administer users'
+  - 'assign user roles'
   - 'view the administration theme'

--- a/html/modules/custom/odsg_access/README.md
+++ b/html/modules/custom/odsg_access/README.md
@@ -1,10 +1,14 @@
 ODSG Access
 ===========
 
-Define permissions to **view** content types per bundle.
+This module defines various permissions.
 
-This module denies **view** access to node pages for users without the
-corresponding `Node Bundle: view published content` permission.
+**Content Types**
+
+This module defines permissions to **view** content types per bundle.
+
+It denies **view** access to node pages for users without the corresponding
+`Node Bundle: view published content` permission.
 
 To work, the `view published content` must be checked for anonymous and
 authenticated users (otherwise they are already denied access).
@@ -13,9 +17,15 @@ This modules only deals with **published** content. Access to unpublished
 content is managed by the `view unpubished content` permission independently
 of this module.
 
+**Roles**
+
+This modules also provides a permission to assign user roles, decoupling it
+from the `administer permissions` permission.
+
 Setup
 -----
 
 1. Enable the module.
 2. Check `view published content` for anonymous and authenticated users.
-3. Set granular `Node Bundle: view published content` for each node types.
+3. Set granular `Node Bundle: view published content` permission for each node
+   types.

--- a/html/modules/custom/odsg_access/odsg_access.module
+++ b/html/modules/custom/odsg_access/odsg_access.module
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Access\AccessResult;
 use Drupal\node\NodeInterface;
 
@@ -27,4 +28,19 @@ function odsg_access_node_access(NodeInterface $node, $op, AccountInterface $acc
   }
   // No opinion, let other modules handle the permissions.
   return AccessResult::neutral();
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter() for 'user_form'.
+ *
+ * Change permission to assign roles.
+ *
+ * @see Drupal\user\AccountForm::form()
+ */
+function odsg_access_form_user_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  // Allow managing the account roles if there are roles and the current user
+  // has the correct permission.
+  $roles_access = !empty($form['account']['roles']['#options']) &&
+                  \Drupal::currentUser()->hasPermission('assign user roles');
+  $form['account']['roles']['#access'] = $roles_access;
 }

--- a/html/modules/custom/odsg_access/odsg_access.permissions.yml
+++ b/html/modules/custom/odsg_access/odsg_access.permissions.yml
@@ -1,2 +1,5 @@
+assign user roles:
+  title: 'Assign user roles'
+  restrict access: true
 permission_callbacks:
   - \Drupal\odsg_access\OdsgAccessPermissions::buildPermissions


### PR DESCRIPTION
Ticket: https://humanitarian.atlassian.net/browse/ODSG-30

By default Drupal has only permission to assign user roles and manage permissions.

This adds a permission to specifically  be able to assign roles to a user and ensure the Administrator role has the permission.