### PR TITLE
[ODSG-29] Hide the password fields in the account form

### DIFF
--- a/html/modules/custom/odsg_general/README.md
+++ b/html/modules/custom/odsg_general/README.md
@@ -3,3 +3,6 @@ ODSG General
 
 This module provides various tweaks including the automatic creation of new
 `Year` terms used by the ODSG documents when appropriate.
+
+It also hides the password fields in the user form. This can be removed if/when
+similar feature is added to the `social_auth_hid` module.

--- a/html/modules/custom/odsg_general/odsg_general.module
+++ b/html/modules/custom/odsg_general/odsg_general.module
@@ -71,3 +71,17 @@ function odsg_general_create_year_terms() {
     ])->save();
   }
 }
+
+/**
+ * Implements hook_form_FORM_ID_alter() for 'user_form'.
+ *
+ * Hide password fields.
+ *
+ * @todo Remove if similar feature is added to the `social_auth_hid` module.
+ *
+ * @see Drupal\user\AccountForm::form()
+ */
+function odsg_general_form_user_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  $form['account']['pass']['#access'] = FALSE;
+  $form['account']['current_pass']['#access'] = FALSE;
+}


### PR DESCRIPTION
Ticket: https://humanitarian.atlassian.net/browse/ODSG-29

This hides the passwords fields in the account form as they are irrelevant since the login is done via HID.

This could be removed if/when an option is added to the `social_auth_hid` module to hide those fields.