### PR TITLE
[ODSG-39] Composer fixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,6 @@
         "drupal/r4032login": "^2.1",
         "drupal/redirect": "^1.6",
         "drupal/social_auth_hid": "^2.6",
-        "drupal/stage_file_proxy": "^1.1",
         "drush/drush": "^10.2.2",
         "oomphinc/composer-installers-extender": "^2.0",
         "symfony/flex": "^1.10",
@@ -82,11 +81,11 @@
         ],
         "post-install-cmd": [
             "DrupalProject\\composer\\ScriptHandler::createRequiredFiles",
-            "git config core.hooksPath git-hooks"
+            "git config core.hooksPath git-hooks || true"
         ],
         "post-update-cmd": [
             "DrupalProject\\composer\\ScriptHandler::createRequiredFiles",
-            "git config core.hooksPath git-hooks"
+            "git config core.hooksPath git-hooks || true"
         ],
         "sass-prepare": "cd html/themes/custom/common_design_subtheme && npm install",
         "sass-build": "cd html/themes/custom/common_design_subtheme && ./node_modules/.bin/sass sass:build",
@@ -118,6 +117,7 @@
             "drush/Commands/{$name}": ["type:drupal-drush"]
         },
         "preserve-paths": [
+            "html/modules/custom",
             "html/themes/custom"
         ],
         "drupal-scaffold": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4af3d4b9d531c52f9922cb844b8795f7",
+    "content-hash": "463cf7c7ee60dee8f7603d72bac76d38",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3250,17 +3250,17 @@
         },
         {
             "name": "drupal/social_api",
-            "version": "3.0.0",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/social_api.git",
-                "reference": "3.0.0"
+                "reference": "3.0.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/social_api-3.0.0.zip",
-                "reference": "3.0.0",
-                "shasum": "b3e5f11413f50fe067afa22fce197ce1402300cc"
+                "url": "https://ftp.drupal.org/files/projects/social_api-3.0.1.zip",
+                "reference": "3.0.1",
+                "shasum": "747652a9e33ace1b29d319bbddf859e227255fa5"
             },
             "require": {
                 "drupal/core": "^8.8 || ^9.0",
@@ -3273,8 +3273,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "3.0.0",
-                    "datestamp": "1609797837",
+                    "version": "3.0.1",
+                    "datestamp": "1628180547",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -3448,83 +3448,6 @@
             "support": {
                 "source": "http://cgit.drupalcode.org/social_auth_hid",
                 "issues": "https://www.drupal.org/project/issues/social_auth_hid"
-            }
-        },
-        {
-            "name": "drupal/stage_file_proxy",
-            "version": "1.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://git.drupalcode.org/project/stage_file_proxy.git",
-                "reference": "8.x-1.1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/stage_file_proxy-8.x-1.1.zip",
-                "reference": "8.x-1.1",
-                "shasum": "bad4d500e56f4e77adb2704ec5d4efdf52340df8"
-            },
-            "require": {
-                "drupal/core": ">=8.7.7"
-            },
-            "type": "drupal-module",
-            "extra": {
-                "drupal": {
-                    "version": "8.x-1.1",
-                    "datestamp": "1601040759",
-                    "security-coverage": {
-                        "status": "covered",
-                        "message": "Covered by Drupal's security advisory policy"
-                    }
-                },
-                "drush": {
-                    "services": {
-                        "stage_file_proxy.drush.services.yml": "^9 || ^10"
-                    }
-                }
-            },
-            "notification-url": "https://packages.drupal.org/8/downloads",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "BarisW",
-                    "homepage": "https://www.drupal.org/user/107229"
-                },
-                {
-                    "name": "geek-merlin",
-                    "homepage": "https://www.drupal.org/user/229048"
-                },
-                {
-                    "name": "greggles",
-                    "homepage": "https://www.drupal.org/user/36762"
-                },
-                {
-                    "name": "markdorison",
-                    "homepage": "https://www.drupal.org/user/346106"
-                },
-                {
-                    "name": "moshe weitzman",
-                    "homepage": "https://www.drupal.org/user/23"
-                },
-                {
-                    "name": "msonnabaum",
-                    "homepage": "https://www.drupal.org/user/75278"
-                },
-                {
-                    "name": "netaustin",
-                    "homepage": "https://www.drupal.org/user/199298"
-                },
-                {
-                    "name": "robwilmshurst",
-                    "homepage": "https://www.drupal.org/user/144488"
-                }
-            ],
-            "description": "Provides stage_file_proxy module.",
-            "homepage": "https://www.drupal.org/project/stage_file_proxy",
-            "support": {
-                "source": "https://git.drupalcode.org/project/stage_file_proxy"
             }
         },
         {


### PR DESCRIPTION
Ticket: ODSG-39

Extension of https://github.com/UN-OCHA/odsg8-site/pull/51.

This fixes an issue with the git-hooks post-install/update commands when building the site image.

It also removes `stage_file_proxy` which shouldn't have been there in the first place and adds "html/modules/custom" to the preserved paths.