### PR TITLE
[ODSG-41] deny access to create users

### DIFF
--- a/html/modules/custom/odsg_general/odsg_general.services.yml
+++ b/html/modules/custom/odsg_general/odsg_general.services.yml
@@ -1,0 +1,5 @@
+services:
+  odsg_general.route_subscriber:
+    class: Drupal\odsg_general\Routing\RouteSubscriber
+    tags:
+      - { name: event_subscriber }

--- a/html/modules/custom/odsg_general/src/Routing/RouteSubscriber.php
+++ b/html/modules/custom/odsg_general/src/Routing/RouteSubscriber.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Drupal\odsg_general\Routing;
+
+use Drupal\Core\Routing\RouteSubscriberBase;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Listens to the dynamic route events.
+ */
+class RouteSubscriber extends RouteSubscriberBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function alterRoutes(RouteCollection $collection) {
+    // Always deny access to '/admin/people/create'.
+    if ($route = $collection->get('user.admin_create')) {
+      $route->setRequirement('_access', 'FALSE');
+    }
+  }
+
+}


### PR DESCRIPTION
Edit: not for merging - see comment below.

https://humanitarian.atlassian.net/browse/ODSG-41

Couldn't see a checkbox to toggle this behaviour, but it is quick and easy to prevent access to the 'create new user' form, so suggesting that. I imagine they're are many other ways to do it, so if we're thinking of making it standard for all sites, please suggest any better ways you can think of.