### PR TITLE
fix: be more definite about php version so gha can detect it

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/unocha/unified-builder:${TAG:-8.0-stable} as builder
+FROM public.ecr.aws/unocha/unified-builder:8.0-stable as builder
 ARG  BRANCH_ENVIRONMENT
 ENV  NODE_ENV=$BRANCH_ENVIRONMENT
 COPY . /srv/www
@@ -16,7 +16,7 @@ RUN cd html/themes/custom/common_design_subtheme && \
 # Copy settings to default site location.
 RUN cp -a docker/settings.php docker/services.yml html/sites/default
 
-FROM public.ecr.aws/unocha/php-k8s:${TAG:-8.0-stable}
+FROM public.ecr.aws/unocha/php-k8s:8.0-stable
 
 ARG VCS_REF
 ARG VCS_URL


### PR DESCRIPTION
Refs: OPS-9006

Surprised to see https://github.com/UN-OCHA/odsg8-site/actions/runs/5208144574 failing, turns out it was building with php8.2 instead of 8.0. Without decoding the [regex](https://github.com/UN-OCHA/actions/blob/80cf32e2ad02da4dee9750014a850a50b6599d21/extract-php-version/entrypoint.js#L34) properly, I think it's because it wasn't expecting a bash substitution, and none of the other repos (that I checked) use this format, so I think we're good to remove the chance to set the version by $TAG. Right?