### PR TITLE
[UNO-777] Change OCHA feeds to use RW API.

### DIFF
--- a/config/user.role.administrator.yml
+++ b/config/user.role.administrator.yml
@@ -1,7 +1,12 @@
 uuid: b597d76c-687b-40e6-8a1f-9cdd772208c6
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  module:
+    - odsg_access
+    - odsg_ocha
+    - system
+    - toolbar
 id: administrator
 label: Administrator
 weight: -6
@@ -9,6 +14,7 @@ is_admin: false
 permissions:
   - 'access toolbar'
   - 'access user profiles'
+  - 'administer ocha feeds'
   - 'administer users'
   - 'assign user roles'
   - 'view the administration theme'

--- a/config/user.role.anonymous.yml
+++ b/config/user.role.anonymous.yml
@@ -1,7 +1,10 @@
 uuid: 93da2f40-879e-4c57-9848-03fb129e98cf
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  module:
+    - odsg_access
+    - system
 _core:
   default_config_hash: j5zLMOdJBqC0bMvSdth5UebkprJB8g_2FXHqhfpJzow
 id: anonymous

--- a/config/user.role.authenticated.yml
+++ b/config/user.role.authenticated.yml
@@ -1,7 +1,10 @@
 uuid: 3abbef29-4c59-4e92-a9a7-bbd119480b37
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  module:
+    - odsg_access
+    - system
 _core:
   default_config_hash: dJ0L2DNSj5q6XVZAGsuVDpJTh5UeYkIPwKrUOOpr8YI
 id: authenticated

--- a/config/user.role.content_manager.yml
+++ b/config/user.role.content_manager.yml
@@ -1,7 +1,28 @@
 uuid: 10f474d9-29fc-41da-ab5c-21fa652f5cd2
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  config:
+    - filter.format.filtered_html
+    - media.type.document
+    - media.type.image
+    - node.type.announcement
+    - node.type.custom_link
+    - node.type.odsg_document
+    - node.type.page
+    - node.type.public_page
+    - taxonomy.vocabulary.document_type_project_report
+    - taxonomy.vocabulary.meeting_title_country
+    - taxonomy.vocabulary.subtype
+  module:
+    - filter
+    - media
+    - node
+    - odsg_access
+    - odsg_ocha
+    - system
+    - taxonomy
+    - toolbar
 id: content_manager
 label: 'Content Manager'
 weight: -7
@@ -14,6 +35,7 @@ permissions:
   - 'access private content'
   - 'access taxonomy overview'
   - 'access toolbar'
+  - 'administer ocha feeds'
   - 'create announcement content'
   - 'create custom_link content'
   - 'create document media'

--- a/config/user.role.odsg_donor_un_employee.yml
+++ b/config/user.role.odsg_donor_un_employee.yml
@@ -1,7 +1,14 @@
 uuid: 75b028ec-1222-4a32-8c29-eb702bb69625
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  config:
+    - filter.format.filtered_html
+  module:
+    - filter
+    - media
+    - odsg_access
+    - system
 id: odsg_donor_un_employee
 label: 'ODSG Donor / UN Employee'
 weight: -8

--- a/config/views.view.ocha_feeds.yml
+++ b/config/views.view.ocha_feeds.yml
@@ -357,9 +357,26 @@ display:
     display_options:
       title: 'Annual Reports - Full'
       pager:
-        type: none
+        type: full
         options:
           offset: 0
+          items_per_page: 40
+          total_pages: null
+          id: 0
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
       query:
         type: views_query
         options:
@@ -387,6 +404,7 @@ display:
       max-age: -1
       contexts:
         - 'languages:language_interface'
+        - url.query_args
       tags: {  }
   block_ocha_core_publications:
     id: block_ocha_core_publications
@@ -422,9 +440,26 @@ display:
     display_options:
       title: 'Core Publications - Full'
       pager:
-        type: none
+        type: full
         options:
           offset: 0
+          items_per_page: 40
+          total_pages: null
+          id: 0
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
       query:
         type: views_query
         options:
@@ -452,6 +487,7 @@ display:
       max-age: -1
       contexts:
         - 'languages:language_interface'
+        - url.query_args
       tags: {  }
   block_ocha_global_humanitarian_overview:
     id: block_ocha_global_humanitarian_overview
@@ -487,9 +523,26 @@ display:
     display_options:
       title: 'Global Humanitarian Overview - Full'
       pager:
-        type: none
+        type: full
         options:
           offset: 0
+          items_per_page: 40
+          total_pages: null
+          id: 0
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
       query:
         type: views_query
         options:
@@ -517,6 +570,7 @@ display:
       max-age: -1
       contexts:
         - 'languages:language_interface'
+        - url.query_args
       tags: {  }
   block_ocha_news_and_updates:
     id: block_ocha_news_and_updates
@@ -1163,9 +1217,26 @@ display:
           empty_zero: false
           hide_alter_empty: false
       pager:
-        type: none
+        type: full
         options:
           offset: 0
+          items_per_page: 40
+          total_pages: null
+          id: 0
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
       style:
         type: html_list
         options:
@@ -1208,6 +1279,7 @@ display:
       max-age: -1
       contexts:
         - 'languages:language_interface'
+        - url.query_args
       tags: {  }
   block_ocha_plan_and_budget:
     id: block_ocha_plan_and_budget
@@ -1243,9 +1315,26 @@ display:
     display_options:
       title: 'Plan & Budget - Full'
       pager:
-        type: none
+        type: full
         options:
           offset: 0
+          items_per_page: 40
+          total_pages: null
+          id: 0
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
       query:
         type: views_query
         options:
@@ -1273,6 +1362,7 @@ display:
       max-age: -1
       contexts:
         - 'languages:language_interface'
+        - url.query_args
       tags: {  }
   block_ocha_strategic_framework:
     id: block_ocha_strategic_framework
@@ -1308,9 +1398,26 @@ display:
     display_options:
       title: 'Strategic Framework - Full'
       pager:
-        type: none
+        type: full
         options:
           offset: 0
+          items_per_page: 40
+          total_pages: null
+          id: 0
+          tags:
+            next: 'Next ›'
+            previous: '‹ Previous'
+            first: '« First'
+            last: 'Last »'
+          expose:
+            items_per_page: false
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '5, 10, 25, 50'
+            items_per_page_options_all: false
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+          quantity: 9
       query:
         type: views_query
         options:
@@ -1338,4 +1445,5 @@ display:
       max-age: -1
       contexts:
         - 'languages:language_interface'
+        - url.query_args
       tags: {  }

--- a/html/modules/custom/odsg_ocha/README.md
+++ b/html/modules/custom/odsg_ocha/README.md
@@ -23,6 +23,12 @@ Available fields are:
 - `file`: URL of the first attachment of the document
 - `image`: URL of the cover preview of the attachment or article image
 
+### Administration
+
+The URLs of the feeds used for the views that use this OCHA feeds plugin can
+be administered under `/admin/config/user-interface/ocha-feeds` for the roles
+with the `administer ocha feeds` permission.
+
 OCHA OCT
 --------
 

--- a/html/modules/custom/odsg_ocha/odsg_ocha.links.menu.yml
+++ b/html/modules/custom/odsg_ocha/odsg_ocha.links.menu.yml
@@ -1,0 +1,5 @@
+odsg_ocha.ocha_feeds.settings:
+  title: Ocha Feeds
+  description: 'Configure Ocha Feeds settings'
+  route_name: odsg_ocha.ocha_feeds.settings
+  parent: system.admin_config_ui

--- a/html/modules/custom/odsg_ocha/odsg_ocha.permissions.yml
+++ b/html/modules/custom/odsg_ocha/odsg_ocha.permissions.yml
@@ -1,0 +1,3 @@
+administer ocha feeds:
+  title: 'Administer ocha feeds'
+  description: 'Administer ocha feeds settings.'

--- a/html/modules/custom/odsg_ocha/odsg_ocha.routing.yml
+++ b/html/modules/custom/odsg_ocha/odsg_ocha.routing.yml
@@ -1,0 +1,7 @@
+odsg_ocha.ocha_feeds.settings:
+  path: '/admin/config/user-interface/ocha-feeds'
+  defaults:
+    _title: 'OCHA Feeds'
+    _form: '\Drupal\odsg_ocha\Form\OchaFeedsSettingsForm'
+  requirements:
+    _permission: 'administer ocha feeds'

--- a/html/modules/custom/odsg_ocha/src/Form/OchaFeedsSettingsForm.php
+++ b/html/modules/custom/odsg_ocha/src/Form/OchaFeedsSettingsForm.php
@@ -81,7 +81,7 @@ class OchaFeedsSettingsForm extends FormBase {
 
     $form['ocha_strategic_framework'] = [
       '#type' => 'textfield',
-      '#title' => $this->t('OOCHA Strategic Framework'),
+      '#title' => $this->t('OCHA Strategic Framework'),
       '#description' => $this->t('Enter a ReliefWeb API URL (ex: https://api.reliefweb.int/v1/reports?appname=odsg.unocha.org&query[value]=source:OCHA).'),
       '#default_value' => $this->state->get('odsg_ocha.feeds.ocha_strategic_framework', ''),
       '#maxlength' => 4096,
@@ -90,7 +90,7 @@ class OchaFeedsSettingsForm extends FormBase {
 
     $form['ocha_news_and_updates'] = [
       '#type' => 'textfield',
-      '#title' => $this->t('OOCHA News and Updates'),
+      '#title' => $this->t('OCHA News and Updates'),
       '#description' => $this->t('Enter the URL of the feed on www.unocha.org for the OCHA News and Stories. Currently disabled.'),
       '#default_value' => $this->state->get('odsg_ocha.feeds.ocha_news_and_updates', ''),
       '#disabled' => TRUE,

--- a/html/modules/custom/odsg_ocha/src/Form/OchaFeedsSettingsForm.php
+++ b/html/modules/custom/odsg_ocha/src/Form/OchaFeedsSettingsForm.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace Drupal\odsg_ocha\Form;
+
+use Drupal\Core\Cache\Cache;
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\State\StateInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Settings form for the OCHA feeds.
+ */
+class OchaFeedsSettingsForm extends FormBase {
+
+  /**
+   * The state service.
+   *
+   * @var \Drupal\Core\State\StateInterface
+   */
+  protected $state;
+
+  /**
+   * Constructor.
+   *
+   * @param \Drupal\Core\State\StateInterface $state
+   *   The state service.
+   */
+  public function __construct(StateInterface $state) {
+    $this->state = $state;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('state')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $form['ocha_core_publications'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('OCHA Core Publications'),
+      '#description' => $this->t('Enter a ReliefWeb API URL (ex: https://api.reliefweb.int/v1/reports?appname=odsg.unocha.org&query[value]=source:OCHA).'),
+      '#default_value' => $this->state->get('odsg_ocha.feeds.ocha_core_publications', ''),
+      '#maxlength' => 4096,
+      '#size' => 300,
+    ];
+
+    $form['ocha_annual_reports'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('OCHA Annual Reports'),
+      '#description' => $this->t('Enter a ReliefWeb API URL (ex: https://api.reliefweb.int/v1/reports?appname=odsg.unocha.org&query[value]=source:OCHA).'),
+      '#default_value' => $this->state->get('odsg_ocha.feeds.ocha_annual_reports', ''),
+      '#maxlength' => 4096,
+      '#size' => 300,
+    ];
+
+    $form['ocha_global_humanitarian_overview'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('OCHA Global Humanitarian Overview'),
+      '#description' => $this->t('Enter a ReliefWeb API URL (ex: https://api.reliefweb.int/v1/reports?appname=odsg.unocha.org&query[value]=source:OCHA).'),
+      '#default_value' => $this->state->get('odsg_ocha.feeds.ocha_global_humanitarian_overview', ''),
+      '#maxlength' => 4096,
+      '#size' => 300,
+    ];
+
+    $form['ocha_plan_and_budget'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('OCHA Plan and Budget'),
+      '#description' => $this->t('Enter a ReliefWeb API URL (ex: https://api.reliefweb.int/v1/reports?appname=odsg.unocha.org&query[value]=source:OCHA).'),
+      '#default_value' => $this->state->get('odsg_ocha.feeds.ocha_plan_and_budget', ''),
+      '#maxlength' => 4096,
+      '#size' => 300,
+    ];
+
+    $form['ocha_strategic_framework'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('OOCHA Strategic Framework'),
+      '#description' => $this->t('Enter a ReliefWeb API URL (ex: https://api.reliefweb.int/v1/reports?appname=odsg.unocha.org&query[value]=source:OCHA).'),
+      '#default_value' => $this->state->get('odsg_ocha.feeds.ocha_strategic_framework', ''),
+      '#maxlength' => 4096,
+      '#size' => 300,
+    ];
+
+    $form['ocha_news_and_updates'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('OOCHA News and Updates'),
+      '#description' => $this->t('Enter the URL of the feed on www.unocha.org for the OCHA News and Stories. Currently disabled.'),
+      '#default_value' => $this->state->get('odsg_ocha.feeds.ocha_news_and_updates', ''),
+      '#disabled' => TRUE,
+      '#maxlength' => 4096,
+      '#size' => 300,
+    ];
+
+    $form['actions']['#type'] = 'actions';
+    $form['actions']['submit'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Save settings'),
+      '#button_type' => 'primary',
+    ];
+    // By default, render the form using system-config-form.html.twig.
+    $form['#theme'] = 'system_config_form';
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $feeds = [
+      'ocha_core_publications',
+      'ocha_annual_reports',
+      'ocha_global_humanitarian_overview',
+      'ocha_plan_and_budget',
+      'ocha_strategic_framework',
+      'ocha_news_and_updates',
+    ];
+
+    foreach ($feeds as $feed) {
+      $this->state->set('odsg_ocha.feeds.' . $feed, $form_state->getValue($feed) ?? '');
+    }
+
+    // Clear the cache of the view that use those feeds.
+    Cache::invalidateTags(['config:views.view.ocha_feeds']);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'odsg_ocha_ocha_feeds_settings';
+  }
+
+}


### PR DESCRIPTION
Refs: UNO-777

This PR changes the logic to use the RW API for the OCHA feeds where possible to reflect the changes with the D10 upgrade of unocha.org.

See ticket for details.

**Important:** the New and Stories block that was on the homepage is not displayed because there is currently no feed for the OCHA stories. That will be handled in a separate PR depending on what is decided in the ticket.

### Post deployment

1. Log in as an administrator or content manager
2. Go to `/admin/config/user-interface/ocha-feeds`
3. Enter the following URLs:
    - Core publications: https://api.reliefweb.int/v1/reports?appname=odsg.unocha.org&profile=list&preset=latest&slim=1&query%5Bvalue%5D=source%3AOCHA+AND+_exists_%3Afile+AND+title.exact%3A%28+%2FOCHA+in+%5B0-9%5D%7B4%7D.%2A%2F+OR+%2FOCHA+Annual+Report+%5B0-9%5D%7B4%7D%2F+OR+%2FReference+Guide+for+OCHA%E2%80%99s+Strategic+Framework.%2A%2F+OR+%2FConsolidated+Appeals+Process.%2AHumanitarian+Appeal+%5B0-9%5D%7B4%7D%2F+OR+%2F%28An+%29%3FOverview+of+the+.%2AConsolidated+Appeals.%2A%2F+OR+%2F%28An+%29%3FOverview+of+Global+Humanitarian+%28Action%7CResponse%29.%2A%2F+OR+%2FOCHA+Management+Plan.%2A%2F+OR+%2FStrategic+Framework.%2A%2F+OR+%2FGlobal+Humanitarian+Overview.%2A%5B0-9%5D%7B4%7D.%2A%2F+OR+%2FOCHA+Plan+and+Budget.%2A%2F+OR+%2FOCHA.%2AStrategic+Plan.%2A%2F+%29&query%5Boperator%5D=AND
    - Annual reports: https://api.reliefweb.int/v1/reports?appname=odsg.unocha.org&profile=list&preset=latest&slim=1&query%5Bvalue%5D=source%3AOCHA+AND+_exists_%3Afile+AND+title.exact%3A%28+%2FOCHA+Annual+Report+%5B0-9%5D%7B4%7D%2F+%29&query%5Boperator%5D=AND
    - GHO: https://api.reliefweb.int/v1/reports?appname=odsg.unocha.org&profile=list&preset=latest&slim=1&query%5Bvalue%5D=source%3AOCHA+AND+_exists_%3Afile+AND+title.exact%3A%28+%2FGlobal+Humanitarian+Overview.%2A%5B0-9%5D%7B4%7D.%2A%2F+%29&query%5Boperator%5D=AND
    - Plan and budget: https://api.reliefweb.int/v1/reports?appname=odsg.unocha.org&profile=list&preset=latest&slim=1&query%5Bvalue%5D=source%3AOCHA+AND+_exists_%3Afile+AND+title.exact%3A%28+%2FOCHA+in+%5B0-9%5D%7B4%7D.%2A%2F+OR+%2FOCHA+Management+Plan.%2A%2F+OR+%2FOCHA+Plan+and+Budget.%2A%2F+%29&query%5Boperator%5D=AND
    - Strategic framework: https://api.reliefweb.int/v1/reports?appname=odsg.unocha.org&profile=list&preset=latest&slim=1&query%5Bvalue%5D=source%3AOCHA+AND+_exists_%3Afile+AND+title.exact%3A%28+%2FReference+Guide+for+OCHA%E2%80%99s+Strategic+Framework.%2A%2F+OR+%2FStrategic+Framework.%2A%2F+OR+%2FOCHA.%2AStrategic+Plan.%2A%2F+%29&query%5Boperator%5D=AND

### Tests

1. Checkout the branch, clear the cache, import the config
2. Follow the post deployment instructions above
3. Check that the `Publications` block on the homepage looks like:
<img width="1258" alt="Screenshot 2023-08-17 at 15 37 51" src="https://github.com/UN-OCHA/odsg8-site/assets/696348/57be5715-8ccf-48eb-a52c-498947b38d1e">
4. Visit the 4 `more` links under this `Publications` block and confirm that it shows a list of documents that looks appropriate for the page (ex: GHO docs for GHO page)
5. Visit the `/resources` page and confirm that the Annual reports, etc. blocks have content
