### PR TITLE
chore: add local stack

### DIFF
--- a/local/README.md
+++ b/local/README.md
@@ -1,0 +1,13 @@
+# Normal usage
+
+### *See the [setup-notes](https://github.com/UN-OCHA/local-reverse-proxy/blob/main/setup-notes.md) for first-time set-up.*
+
+## To start
+`docker compose -f local/docker-compose.yml up -d`
+## To enter the container
+`docker exec -it odsg-local-site sh`
+## To stop
+`docker compose -f local/docker-compose.yml down`
+
+## Notes
+Composer should be run from inside the container.

--- a/local/docker-compose.yml
+++ b/local/docker-compose.yml
@@ -1,0 +1,84 @@
+version: "2.2"
+name: odsg-local
+
+networks:
+  default:
+  proxy:
+    name: ${PROXY:-proxy}
+    external: TRUE
+
+volumes:
+  site-database:
+  site-public:
+  site-private:
+
+services:
+  mysql:
+    image: public.ecr.aws/unocha/mysql:10.6
+    hostname: odsg-local-mysql
+    container_name: odsg-local-mysql
+    environment:
+      - MYSQL_DB=odsg
+      - MYSQL_USER=odsg
+      - MYSQL_PASS=odsg
+    volumes:
+      - "site-database:/var/lib/mysql:rw"
+    networks:
+      - default
+
+  drupal:
+    image: public.ecr.aws/unocha/odsg-site:local
+    hostname: odsg-local-site
+    container_name: odsg-local-site
+    depends_on:
+      - mysql
+    volumes:
+      - "./shared/settings:/srv/www/shared/settings:ro"
+      # Mount the composer files and patches.
+      - "../composer.json:/srv/www/composer.json:rw"
+      - "../composer.patches.json:/srv/www/composer.patches.json:rw"
+      - "../composer.lock:/srv/www/composer.lock:rw"
+      - "../PATCHES:/srv/www/PATCHES:rw"
+      # Mount scripts for composer install.
+      - "../scripts:/srv/www/scripts:ro"
+      # Mount a database directory for import.
+      - "../database:/srv/www/database:rw"
+      # Mount volumes for the private and public files.
+      - "site-public:/srv/www/html/sites/default/files:rw"
+      - "site-private:/srv/www/html/sites/default/private:rw"
+      # Mount the folders needed for the tests.
+      - "../phpcs.xml:/srv/www/phpcs.xml:ro"
+      - "../phpunit.xml:/srv/www/phpunit.xml:ro"
+      # Mount local custom code.
+      - "../html/modules/custom:/srv/www/html/modules/custom:rw"
+      - "../html/themes/custom:/srv/www/html/themes/custom:rw"
+      # Mount configuration and allow overriding it.
+      - "../config:/srv/www/config:rw"
+      - "../config_dev:/srv/www/config_dev:rw"
+    environment:
+      - TERM=xterm
+      - ENVIRONMENT=dev
+      - NGINX_SERVERNAME=odsg-local.test
+      - NGINX_OVERRIDE_PROTOCOL=HTTP,odsg-local.test
+      - DRUSH_OPTIONS_URI=https://odsg-local.test
+      - DRUPAL_DB_DATABASE=odsg
+      - DRUPAL_DB_USERNAME=odsg
+      - DRUPAL_DB_PASSWORD=odsg
+      - DRUPAL_DB_HOST=mysql
+      - DRUPAL_DB_DRIVER=mysql
+      - PHP_ENVIRONMENT=dev
+      - PHP_XDEBUG=true
+      # Rate limiting.
+      - NGINX_LIMIT_HUMANS=1024r/s
+      - NGINX_BURST_HUMANS=1024
+      # Local proxy.
+      - VIRTUAL_HOST=odsg-local.test
+      - VIRTUAL_PORT=80
+      - VIRTUAL_NETWORK=${PROXY:-proxy}
+      - HTTPS_METHOD=noredirect
+    labels:
+      caddy: odsg-local.test
+      caddy.reverse_proxy: "{{upstreams}}"
+    networks:
+      - default
+      - proxy

--- a/local/install.sh
+++ b/local/install.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+
+set -e -u
+
+# Usage.
+usage() {
+  echo "Usage: ./local/install.sh [OPTIONS]" >&2
+  echo "-h                    : Display usage" >&2
+  echo "-m                    : Create local image" >&2
+  echo "-i                    : Install site" >&2
+  echo "-c                    : Use existing config to install site" >&2
+  echo "-p network            : Indicate the local proxy network name (defaults to 'proxy')" >&2
+  echo "-x                    : Shutdown and remove the site containers" >&2
+  echo "-v                    : Also remove the volumes when shutting down the containers" >&2
+  exit 1
+}
+
+sitename="odsg"
+create_image="no"
+install_site="no"
+use_existing_config="no"
+proxy_name="proxy"
+shutdown="no"
+shutdown_options=""
+
+# Parse options.
+while getopts "hmicp:xv" opt; do
+  case $opt in
+    h)
+      usage
+      ;;
+    m)
+      create_image="yes"
+      ;;
+    i)
+      install_site="yes"
+      ;;
+    c)
+      use_existing_config="yes"
+      ;;
+    p)
+      proxy_name="${OPTARG//,/ }"
+      ;;
+    x)
+      shutdown="yes"
+      ;;
+    v)
+      shutdown_options="$shutdown_options -v"
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+
+# Stop and remove the containers.
+if [ "$shutdown" = "yes" ]; then
+  echo "Stop and remove the containers."
+  PROXY=$proxy_name docker-compose -p "${sitename}-local" -f local/docker-compose.yml down "$shutdown_options" || true
+  exit 0
+fi
+
+
+# Build local image.
+if [ "$create_image" = "yes" ]; then
+  echo "Build local image."
+  make
+fi;
+
+# Create the site, memcache and mysql containers.
+echo "Create the site and mysql containers."
+PROXY=$proxy_name docker-compose -p "${sitename}-local" -f local/docker-compose.yml up -d
+
+# Dump some information about the created containers.
+echo "Dump some information about the created containers."
+docker ps -a -fname="${sitename}-local"
+
+# Wait a bit for memcache and mysql to be ready.
+echo "Wait a bit for memcache and mysql to be ready."
+sleep 10
+
+# Install the site.
+if [ "$install_site" = "yes" ]; then
+  # Ensure the file directories are writable.
+  echo "Ensure the file directories are writable."
+  docker exec -it "${sitename}-local-site" chmod -R 777 /srv/www/html/sites/default/files /srv/www/html/sites/default/private
+
+  # Install the dev dependencies.
+  echo "Install the common design subtheme if not present already"
+  docker exec -it -w /srv/www "${sitename}-local-site" composer run sub-theme
+
+  # Install the site with the existing config.
+  if [ "$use_existing_config" = "yes" ]; then
+    echo "Install the site with the existing config."
+    docker exec -it "${sitename}-local-site" drush -y si --existing-config minimal install_configure_form.enable_update_status_emails=NULL
+  else
+    echo "Install the site from scratch."
+    docker exec -it "${sitename}-local-site" drush -y si minimal install_configure_form.enable_update_status_emails=NULL
+  fi
+
+  # Import the configuration.
+  docker exec -it "${sitename}-local-site" drush -y cim
+fi

--- a/local/shared/settings/services.yml
+++ b/local/shared/settings/services.yml
@@ -1,0 +1,49 @@
+# Local development services.
+#
+# To activate this feature, follow the instructions at the top of the
+# 'example.settings.local.php' file, which sits next to this file.
+parameters:
+  http.response.debug_cacheability_headers: false
+  twig.config:
+    # Twig debugging:
+    #
+    # When debugging is enabled:
+    # - The markup of each Twig template is surrounded by HTML comments that
+    #   contain theming information, such as template file name suggestions.
+    # - Note that this debugging markup will cause automated tests that directly
+    #   check rendered HTML to fail. When running automated tests, 'debug'
+    #   should be set to FALSE.
+    # - The dump() function can be used in Twig templates to output information
+    #   about template variables.
+    # - Twig templates are automatically recompiled whenever the source code
+    #   changes (see auto_reload below).
+    #
+    # For more information about debugging Twig templates, see
+    # https://www.drupal.org/node/1906392.
+    #
+    # Not recommended in production environments
+    # @default false
+    debug: false
+    # Twig auto-reload:
+    #
+    # Automatically recompile Twig templates whenever the source code changes.
+    # If you don't provide a value for auto_reload, it will be determined
+    # based on the value of debug.
+    #
+    # Not recommended in production environments
+    # @default null
+    auto_reload: false
+    # Twig cache:
+    #
+    # By default, Twig templates will be compiled and stored in the filesystem
+    # to increase performance. Disabling the Twig cache will recompile the
+    # templates from source each time they are used. In most cases the
+    # auto_reload setting above should be enabled rather than disabling the
+    # Twig cache.
+    #
+    # Not recommended in production environments
+    # @default true
+    cache: true
+services:
+  cache.backend.null:
+    class: Drupal\Core\Cache\NullBackendFactory

--- a/local/shared/settings/settings.local.php
+++ b/local/shared/settings/settings.local.php
@@ -1,0 +1,155 @@
+<?php
+
+// @codingStandardsIgnoreFile
+
+/**
+ * @file
+ * Local development override configuration feature.
+ *
+ * To activate this feature, copy and rename it such that its path plus
+ * filename is 'sites/default/settings.local.php'. Then, go to the bottom of
+ * 'sites/default/settings.php' and uncomment the commented lines that mention
+ * 'settings.local.php'.
+ *
+ * If you are using a site name in the path, such as 'sites/example.com', copy
+ * this file to 'sites/example.com/settings.local.php', and uncomment the lines
+ * at the bottom of 'sites/example.com/settings.php'.
+ */
+
+/**
+ * Assertions.
+ *
+ * The Drupal project primarily uses runtime assertions to enforce the
+ * expectations of the API by failing when incorrect calls are made by code
+ * under development.
+ *
+ * @see http://php.net/assert
+ * @see https://www.drupal.org/node/2492225
+ *
+ * If you are using PHP 7.0 it is strongly recommended that you set
+ * zend.assertions=1 in the PHP.ini file (It cannot be changed from .htaccess
+ * or runtime) on development machines and to 0 in production.
+ *
+ * @see https://wiki.php.net/rfc/expectations
+ */
+assert_options(ASSERT_ACTIVE, TRUE);
+\Drupal\Component\Assertion\Handle::register();
+
+/**
+ * Enable local development services.
+ */
+$settings['container_yamls'][] = '/srv/www/shared/settings/services.yml';
+
+/**
+ * Show all error messages, with backtrace information.
+ *
+ * In case the error level could not be fetched from the database, as for
+ * example the database connection failed, we rely only on this value.
+ */
+$config['system.logging']['error_level'] = 'verbose';
+
+/**
+ * Disable CSS and JS aggregation.
+ */
+$config['system.performance']['css']['preprocess'] = FALSE;
+$config['system.performance']['js']['preprocess'] = FALSE;
+
+/**
+ * Disable the render cache.
+ *
+ * Note: you should test with the render cache enabled, to ensure the correct
+ * cacheability metadata is present. However, in the early stages of
+ * development, you may want to disable it.
+ *
+ * This setting disables the render cache by using the Null cache back-end
+ * defined by the development.services.yml file above.
+ *
+ * Only use this setting once the site has been installed.
+ */
+# $settings['cache']['bins']['render'] = 'cache.backend.null';
+
+/**
+ * Disable caching for migrations.
+ *
+ * Uncomment the code below to only store migrations in memory and not in the
+ * database. This makes it easier to develop custom migrations.
+ */
+# $settings['cache']['bins']['discovery_migration'] = 'cache.backend.memory';
+
+/**
+ * Disable Internal Page Cache.
+ *
+ * Note: you should test with Internal Page Cache enabled, to ensure the correct
+ * cacheability metadata is present. However, in the early stages of
+ * development, you may want to disable it.
+ *
+ * This setting disables the page cache by using the Null cache back-end
+ * defined by the development.services.yml file above.
+ *
+ * Only use this setting once the site has been installed.
+ */
+# $settings['cache']['bins']['page'] = 'cache.backend.null';
+
+/**
+ * Disable Dynamic Page Cache.
+ *
+ * Note: you should test with Dynamic Page Cache enabled, to ensure the correct
+ * cacheability metadata is present (and hence the expected behavior). However,
+ * in the early stages of development, you may want to disable it.
+ */
+# $settings['cache']['bins']['dynamic_page_cache'] = 'cache.backend.null';
+
+/**
+ * Allow test modules and themes to be installed.
+ *
+ * Drupal ignores test modules and themes by default for performance reasons.
+ * During development it can be useful to install test extensions for debugging
+ * purposes.
+ */
+# $settings['extension_discovery_scan_tests'] = TRUE;
+
+/**
+ * Enable access to rebuild.php.
+ *
+ * This setting can be enabled to allow Drupal's php and database cached
+ * storage to be cleared via the rebuild.php page. Access to this page can also
+ * be gained by generating a query string from rebuild_token_calculator.sh and
+ * using these parameters in a request to rebuild.php.
+ */
+$settings['rebuild_access'] = TRUE;
+
+/**
+ * Skip file system permissions hardening.
+ *
+ * The system module will periodically check the permissions of your site's
+ * site directory to ensure that it is not writable by the website user. For
+ * sites that are managed with a version control system, this can cause problems
+ * when files in that directory such as settings.php are updated, because the
+ * user pulling in the changes won't have permissions to modify files in the
+ * directory.
+ */
+$settings['skip_permissions_hardening'] = TRUE;
+
+// Workaround for permission issues with NFS shares
+$settings['file_chmod_directory'] = 0777;
+$settings['file_chmod_file'] = 0666;
+
+# File system settings.
+$config['system.file']['path']['temporary'] = '/tmp';
+$settings['file_private_path'] = '/srv/www/html/sites/default/private';
+
+// Enable config_split locally.
+$config['config_split.config_split.config_dev']['status'] = TRUE;
+
+// Default sync directory.
+$settings['config_sync_directory'] = '/srv/www/config';
+
+// Hash salt.
+$settings['hash_salt'] = 'odsg-local-site-salt';
+
+// Ensure the dev_mod module configuration is not saved.
+if (isset($settings['config_exclude_modules']) && is_array($settings['config_exclude_modules'])) {
+  $settings['config_exclude_modules'][] = 'dev_mode';
+} else {
+  $settings['config_exclude_modules'] = ['dev_mode'];
+}


### PR DESCRIPTION
Refs: ODSG-46

I saw this ticket created and already had a version of the local stack ready.

I see there are some small differences between the local stacks and might be good to point those out so we can use the same for all. 

For example, this PR currently refers to https://github.com/UN-OCHA/local-reverse-proxy/blob/main/setup-notes.md for the standard set-up notes, but I think it might be better to move those notes to the starterkit so that they're more discoverable.