### PR TITLE
chore: update allowed_formats module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "composer/installers": "^1.12",
         "cweagans/composer-patches": "^1.7",
         "drupal/admin_denied": "^2.0",
-        "drupal/allowed_formats": "^2.0",
+        "drupal/allowed_formats": "^3",
         "drupal/classy": "^1.0",
         "drupal/components": "^3.0@beta",
         "drupal/config_filter": "^2.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "442155250dffc58c4d80f21c2fea648f",
+    "content-hash": "e71a7eeda6fef9610effc24b8aa81a39",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2220,26 +2220,29 @@
         },
         {
             "name": "drupal/allowed_formats",
-            "version": "2.0.0",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/allowed_formats.git",
-                "reference": "2.0.0"
+                "reference": "3.0.0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/allowed_formats-2.0.0.zip",
-                "reference": "2.0.0",
-                "shasum": "ac6c6d398f303608ced7e9cd9d4556a728dc41f0"
+                "url": "https://ftp.drupal.org/files/projects/allowed_formats-3.0.0.zip",
+                "reference": "3.0.0",
+                "shasum": "1dad855db0e12fa3cdef8ca4e3bfc98f89090490"
             },
             "require": {
-                "drupal/core": "^9.2 || ^10"
+                "drupal/core": "^10.1"
+            },
+            "conflict": {
+                "drupal/core": "<10.1.0"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "2.0.0",
-                    "datestamp": "1669170410",
+                    "version": "3.0.0",
+                    "datestamp": "1693983469",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -2272,7 +2275,7 @@
                     "role": "Maintainer"
                 }
             ],
-            "description": "Limit which text formats are available for each field instance.",
+            "description": "Hides info about the selected text format. The 'allowed formats' functionality has been moved to core since Drupal 10.1.0.",
             "homepage": "https://www.drupal.org/project/allowed_formats",
             "support": {
                 "source": "http://cgit.drupalcode.org/allowed_formats",

--- a/config/field.field.node.announcement.body.yml
+++ b/config/field.field.node.announcement.body.yml
@@ -26,4 +26,5 @@ default_value_callback: ''
 settings:
   display_summary: false
   required_summary: false
+  allowed_formats: {  }
 field_type: text_with_summary

--- a/config/field.field.node.odsg_document.body.yml
+++ b/config/field.field.node.odsg_document.body.yml
@@ -26,4 +26,5 @@ default_value_callback: ''
 settings:
   display_summary: false
   required_summary: false
+  allowed_formats: {  }
 field_type: text_with_summary

--- a/config/field.field.node.page.body.yml
+++ b/config/field.field.node.page.body.yml
@@ -26,4 +26,5 @@ default_value_callback: ''
 settings:
   display_summary: false
   required_summary: false
+  allowed_formats: {  }
 field_type: text_with_summary

--- a/config/field.field.node.page.field_sidebar.yml
+++ b/config/field.field.node.page.field_sidebar.yml
@@ -23,5 +23,6 @@ required: false
 translatable: false
 default_value: {  }
 default_value_callback: ''
-settings: {  }
+settings:
+  allowed_formats: {  }
 field_type: text_long

--- a/config/field.field.node.public_page.body.yml
+++ b/config/field.field.node.public_page.body.yml
@@ -26,4 +26,5 @@ default_value_callback: ''
 settings:
   display_summary: false
   required_summary: false
+  allowed_formats: {  }
 field_type: text_with_summary


### PR DESCRIPTION
Refs: OPS-9884

This got missed in the D10 upgrade - there appear to be no allowed formats configured, so maybe we didn't need the module after all.
Update instructions: https://www.drupal.org/project/allowed_formats/