### PR TITLE
Deploy 19-11-2024

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 All notable changes to this project will be documented in this file.
 <!--- END HEADER -->
 
+## [2.1.8](https://github.com/UN-OCHA/odsg8-site/compare/v2.1.7...v2.1.8) (2024-11-18)
+
+### Chores
+
+* Add csp for vimeo iframes ([5c0057](https://github.com/UN-OCHA/odsg8-site/commit/5c00579d1bfdbf2b603fe0e78ac27405ccc5415f))
+* Update all outdated drupal/* unocha/* drush/* packages. ([3e157c](https://github.com/UN-OCHA/odsg8-site/commit/3e157c255424774296898f6ad334b6996969ff9a), [719d53](https://github.com/UN-OCHA/odsg8-site/commit/719d53d5c4623fd805230781cbed400f50d7a894), [6569dd](https://github.com/UN-OCHA/odsg8-site/commit/6569dd8cbd81dc75224aa300723a3ddf72eb98a4), [c68ad8](https://github.com/UN-OCHA/odsg8-site/commit/c68ad8b9eadcb5e9cf36f6a014f22f52175a976a), [f2672a](https://github.com/UN-OCHA/odsg8-site/commit/f2672afa9554b06b7ddf7329535463b90c39dff4))
+
 ## [2.1.7](https://github.com/UN-OCHA/odsg8-site/compare/v2.1.6...v2.1.7) (2024-10-15)
 
 ### Bug Fixes

--- a/composer.json
+++ b/composer.json
@@ -229,5 +229,5 @@
             "scripts\\composer\\DrupalLenientRequirement::changeVersionConstraint"
         ]
     },
-    "version": "2.1.7"
+    "version": "2.1.8"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "714a5039ef338074851c396e9db0f71a",
+    "content-hash": "8585c94d2ae5941b80a58a46fc968b10",
     "packages": [
         {
             "name": "asm89/stack-cors",


### PR DESCRIPTION
## [2.1.8](https://github.com/UN-OCHA/odsg8-site/compare/v2.1.7...v2.1.8) (2024-11-18)

### Chores

* Add csp for vimeo iframes ([5c0057](https://github.com/UN-OCHA/odsg8-site/commit/5c00579d1bfdbf2b603fe0e78ac27405ccc5415f))
* Update all outdated drupal/* unocha/* drush/* packages. ([3e157c](https://github.com/UN-OCHA/odsg8-site/commit/3e157c255424774296898f6ad334b6996969ff9a), [719d53](https://github.com/UN-OCHA/odsg8-site/commit/719d53d5c4623fd805230781cbed400f50d7a894), [6569dd](https://github.com/UN-OCHA/odsg8-site/commit/6569dd8cbd81dc75224aa300723a3ddf72eb98a4), [c68ad8](https://github.com/UN-OCHA/odsg8-site/commit/c68ad8b9eadcb5e9cf36f6a014f22f52175a976a), [f2672a](https://github.com/UN-OCHA/odsg8-site/commit/f2672afa9554b06b7ddf7329535463b90c39dff4))

## Composer changes

| Production Changes                | From    | To      | Compare                                                                             |
|-----------------------------------|---------|---------|-------------------------------------------------------------------------------------|
| aws/aws-crt-php                   | v1.2.6  | v1.2.7  | [...](https://github.com/awslabs/aws-crt-php/compare/v1.2.6...v1.2.7)               |
| aws/aws-sdk-php                   | 3.323.4 | 3.326.0 | [...](https://github.com/aws/aws-sdk-php/compare/3.323.4...3.326.0)                 |
| behat/mink                        | v1.11.0 | v1.12.0 | [...](https://github.com/minkphp/Mink/compare/v1.11.0...v1.12.0)                    |
| composer/ca-bundle                | 1.5.2   | 1.5.3   | [...](https://github.com/composer/ca-bundle/compare/1.5.2...1.5.3)                  |
| composer/composer                 | 2.8.1   | 2.8.2   | [...](https://github.com/composer/composer/compare/2.8.1...2.8.2)                   |
| composer/pcre                     | 3.3.1   | 3.3.2   | [...](https://github.com/composer/pcre/compare/3.3.1...3.3.2)                       |
| consolidation/output-formatters   | 4.5.0   | 4.6.0   | [...](https://github.com/consolidation/output-formatters/compare/4.5.0...4.6.0)     |
| drupal/core                       | 10.3.6  | 10.3.8  | [...](https://github.com/drupal/core/compare/10.3.6...10.3.8)                       |
| drupal/core-composer-scaffold     | 10.3.6  | 10.3.8  | [...](https://github.com/drupal/core-composer-scaffold/compare/10.3.6...10.3.8)     |
| drupal/core-dev                   | 10.3.6  | 10.3.8  | [...](https://github.com/drupal/core-dev/compare/10.3.6...10.3.8)                   |
| drupal/core-project-message       | 10.3.6  | 10.3.8  | [...](https://github.com/drupal/core-project-message/compare/10.3.6...10.3.8)       |
| drupal/core-recommended           | 10.3.6  | 10.3.8  | [...](https://github.com/drupal/core-recommended/compare/10.3.6...10.3.8)           |
| google/protobuf                   | v3.25.5 | v4.28.3 | [...](https://github.com/protocolbuffers/protobuf-php/compare/v3.25.5...v4.28.3)    |
| guzzlehttp/promises               | 2.0.3   | 2.0.4   | [...](https://github.com/guzzle/promises/compare/2.0.3...2.0.4)                     |
| league/container                  | 4.2.2   | 4.2.4   | [...](https://github.com/thephpleague/container/compare/4.2.2...4.2.4)              |
| myclabs/deep-copy                 | 1.12.0  | 1.12.1  | [...](https://github.com/myclabs/DeepCopy/compare/1.12.0...1.12.1)                  |
| open-telemetry/api                | 1.1.0   | 1.1.1   | [...](https://github.com/opentelemetry-php/api/compare/1.1.0...1.1.1)               |
| open-telemetry/gen-otlp-protobuf  | 1.2.0   | 1.2.1   | [...](https://github.com/opentelemetry-php/gen-otlp-protobuf/compare/1.2.0...1.2.1) |
| open-telemetry/sdk                | 1.1.0   | 1.1.2   | [...](https://github.com/opentelemetry-php/sdk/compare/1.1.0...1.1.2)               |
| phpdocumentor/reflection-docblock | 5.4.1   | 5.6.0   | [...](https://github.com/phpDocumentor/ReflectionDocBlock/compare/5.4.1...5.6.0)    |
| phpdocumentor/type-resolver       | 1.8.2   | 1.10.0  | [...](https://github.com/phpDocumentor/TypeResolver/compare/1.8.2...1.10.0)         |
| phpstan/phpdoc-parser             | 1.32.0  | 1.33.0  | [...](https://github.com/phpstan/phpdoc-parser/compare/1.32.0...1.33.0)             |
| phpstan/phpstan                   | 1.12.6  | 1.12.10 | [...](https://github.com/phpstan/phpstan/compare/1.12.6...1.12.10)                  |
| phpstan/phpstan-phpunit           | 1.4.0   | 1.4.1   | [...](https://github.com/phpstan/phpstan-phpunit/compare/1.4.0...1.4.1)             |
| squizlabs/php_codesniffer         | 3.10.3  | 3.11.0  | [...](https://github.com/PHPCSStandards/PHP_CodeSniffer/compare/3.10.3...3.11.0)    |
| symfony/browser-kit               | v6.4.8  | v6.4.13 | [...](https://github.com/symfony/browser-kit/compare/v6.4.8...v6.4.13)              |
| symfony/console                   | v6.4.12 | v6.4.15 | [...](https://github.com/symfony/console/compare/v6.4.12...v6.4.15)                 |
| symfony/css-selector              | v6.4.8  | v6.4.13 | [...](https://github.com/symfony/css-selector/compare/v6.4.8...v6.4.13)             |
| symfony/dependency-injection      | v6.4.12 | v6.4.15 | [...](https://github.com/symfony/dependency-injection/compare/v6.4.12...v6.4.15)    |
| symfony/dom-crawler               | v6.4.12 | v6.4.13 | [...](https://github.com/symfony/dom-crawler/compare/v6.4.12...v6.4.13)             |
| symfony/error-handler             | v6.4.10 | v6.4.14 | [...](https://github.com/symfony/error-handler/compare/v6.4.10...v6.4.14)           |
| symfony/event-dispatcher          | v6.4.8  | v6.4.13 | [...](https://github.com/symfony/event-dispatcher/compare/v6.4.8...v6.4.13)         |
| symfony/filesystem                | v6.4.12 | v6.4.13 | [...](https://github.com/symfony/filesystem/compare/v6.4.12...v6.4.13)              |
| symfony/finder                    | v6.4.11 | v6.4.13 | [...](https://github.com/symfony/finder/compare/v6.4.11...v6.4.13)                  |
| symfony/http-foundation           | v6.4.12 | v6.4.15 | [...](https://github.com/symfony/http-foundation/compare/v6.4.12...v6.4.15)         |
| symfony/http-kernel               | v6.4.12 | v6.4.15 | [...](https://github.com/symfony/http-kernel/compare/v6.4.12...v6.4.15)             |
| symfony/lock                      | v6.4.8  | v6.4.13 | [...](https://github.com/symfony/lock/compare/v6.4.8...v6.4.13)                     |
| symfony/mailer                    | v6.4.12 | v6.4.13 | [...](https://github.com/symfony/mailer/compare/v6.4.12...v6.4.13)                  |
| symfony/mime                      | v6.4.12 | v6.4.13 | [...](https://github.com/symfony/mime/compare/v6.4.12...v6.4.13)                    |
| symfony/phpunit-bridge            | v6.4.11 | v6.4.13 | [...](https://github.com/symfony/phpunit-bridge/compare/v6.4.11...v6.4.13)          |
| symfony/process                   | v6.4.12 | v6.4.15 | [...](https://github.com/symfony/process/compare/v6.4.12...v6.4.15)                 |
| symfony/psr-http-message-bridge   | v6.4.11 | v6.4.13 | [...](https://github.com/symfony/psr-http-message-bridge/compare/v6.4.11...v6.4.13) |
| symfony/routing                   | v6.4.12 | v6.4.13 | [...](https://github.com/symfony/routing/compare/v6.4.12...v6.4.13)                 |
| symfony/serializer                | v6.4.12 | v6.4.15 | [...](https://github.com/symfony/serializer/compare/v6.4.12...v6.4.15)              |
| symfony/string                    | v6.4.12 | v6.4.15 | [...](https://github.com/symfony/string/compare/v6.4.12...v6.4.15)                  |
| symfony/validator                 | v6.4.12 | v6.4.15 | [...](https://github.com/symfony/validator/compare/v6.4.12...v6.4.15)               |
| symfony/var-dumper                | v6.4.11 | v6.4.15 | [...](https://github.com/symfony/var-dumper/compare/v6.4.11...v6.4.15)              |
| symfony/var-exporter              | v6.4.9  | v6.4.13 | [...](https://github.com/symfony/var-exporter/compare/v6.4.9...v6.4.13)             |
| symfony/yaml                      | v6.4.12 | v6.4.13 | [...](https://github.com/symfony/yaml/compare/v6.4.12...v6.4.13)                    |
| twig/twig                         | v3.14.0 | v3.14.2 | [...](https://github.com/twigphp/Twig/compare/v3.14.0...v3.14.2)                    |

