### PR TITLE
Deploy 17-12-2024

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 All notable changes to this project will be documented in this file.
 <!--- END HEADER -->
 
+## [2.1.10](https://github.com/UN-OCHA/odsg8-site/compare/v2.1.9...v2.1.10) (2024-12-16)
+
+### Chores
+
+* Update all outdated drupal/* unocha/* drush/* packages. ([2b7f60](https://github.com/UN-OCHA/odsg8-site/commit/2b7f600d909c1b107d0ff5de10778954af09cb72), [ecaf7b](https://github.com/UN-OCHA/odsg8-site/commit/ecaf7b83a89fe26fe4d99a41cefbe689e494aa7b), [93df09](https://github.com/UN-OCHA/odsg8-site/commit/93df09393e992eb033219d951d8ed6aa6cee96d0))
+
 ## [2.1.9](https://github.com/UN-OCHA/odsg8-site/compare/v2.1.8...v2.1.9) (2024-11-21)
 
 ### Chores

--- a/composer.json
+++ b/composer.json
@@ -229,5 +229,5 @@
             "scripts\\composer\\DrupalLenientRequirement::changeVersionConstraint"
         ]
     },
-    "version": "2.1.9"
+    "version": "2.1.10"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3dc8650dcfe4aaddc074a433c550c543",
+    "content-hash": "63a0bcf67673b6d01e904d6f9f185c89",
     "packages": [
         {
             "name": "asm89/stack-cors",


### PR DESCRIPTION
## [2.1.10](https://github.com/UN-OCHA/odsg8-site/compare/v2.1.9...v2.1.10) (2024-12-16)

### Chores

* Update all outdated drupal/* unocha/* drush/* packages. ([2b7f60](https://github.com/UN-OCHA/odsg8-site/commit/2b7f600d909c1b107d0ff5de10778954af09cb72), [ecaf7b](https://github.com/UN-OCHA/odsg8-site/commit/ecaf7b83a89fe26fe4d99a41cefbe689e494aa7b), [93df09](https://github.com/UN-OCHA/odsg8-site/commit/93df09393e992eb033219d951d8ed6aa6cee96d0))

## Composer changes

| Production Changes                 | From      | To       | Compare                                                                                  |
|------------------------------------|-----------|----------|------------------------------------------------------------------------------------------|
| aws/aws-sdk-php                    | 3.328.3   | 3.334.4  | [...](https://github.com/aws/aws-sdk-php/compare/3.328.3...3.334.4)                      |
| composer/ca-bundle                 | 1.5.3     | 1.5.4    | [...](https://github.com/composer/ca-bundle/compare/1.5.3...1.5.4)                       |
| composer/class-map-generator       | 1.4.0     | 1.5.0    | [...](https://github.com/composer/class-map-generator/compare/1.4.0...1.5.0)             |
| composer/composer                  | 2.8.3     | 2.8.4    | [...](https://github.com/composer/composer/compare/2.8.3...2.8.4)                        |
| doctrine/deprecations              | 1.1.3     | 1.1.4    | [...](https://github.com/doctrine/deprecations/compare/1.1.3...1.1.4)                    |
| drupal/coder                       | 8.3.25    | 8.3.26   | [...](https://github.com/pfrenssen/coder/compare/8.3.25...8.3.26)                        |
| drupal/core                        | 10.3.9    | 10.3.10  | [...](https://github.com/drupal/core/compare/10.3.9...10.3.10)                           |
| drupal/core-composer-scaffold      | 10.3.9    | 10.3.10  | [...](https://github.com/drupal/core-composer-scaffold/compare/10.3.9...10.3.10)         |
| drupal/core-dev                    | 10.3.9    | 10.3.10  | [...](https://github.com/drupal/core-dev/compare/10.3.9...10.3.10)                       |
| drupal/core-project-message        | 10.3.9    | 10.3.10  | [...](https://github.com/drupal/core-project-message/compare/10.3.9...10.3.10)           |
| drupal/core-recommended            | 10.3.9    | 10.3.10  | [...](https://github.com/drupal/core-recommended/compare/10.3.9...10.3.10)               |
| drupal/stage_file_proxy            | 3.1.3     | 3.1.4    | [...](https://git.drupalcode.org/project/stage_file_proxy/compare/3.1.3...3.1.4)         |
| google/protobuf                    | v4.28.3   | v4.29.1  | [...](https://github.com/protocolbuffers/protobuf-php/compare/v4.28.3...v4.29.1)         |
| grasmash/expander                  | 3.0.0     | 3.0.1    | [...](https://github.com/grasmash/expander/compare/3.0.0...3.0.1)                        |
| league/oauth2-client               | 2.7.0     | 2.8.0    | [...](https://github.com/thephpleague/oauth2-client/compare/2.7.0...2.8.0)               |
| mglaman/phpstan-drupal             | 1.3.1     | 1.3.2    | [...](https://github.com/mglaman/phpstan-drupal/compare/1.3.1...1.3.2)                   |
| paragonie/random_compat            | v9.99.100 | REMOVED  |                                                                                          |
| pear/pear-core-minimal             | v1.10.15  | v1.10.16 | [...](https://github.com/pear/pear-core-minimal/compare/v1.10.15...v1.10.16)             |
| php-http/guzzle7-adapter           | 1.0.0     | 1.1.0    | [...](https://github.com/php-http/guzzle7-adapter/compare/1.0.0...1.1.0)                 |
| phpdocumentor/reflection-docblock  | 5.6.0     | 5.6.1    | [...](https://github.com/phpDocumentor/ReflectionDocBlock/compare/5.6.0...5.6.1)         |
| phpstan/phpstan                    | 1.12.11   | 1.12.12  | [...](https://github.com/phpstan/phpstan/compare/1.12.11...1.12.12)                      |
| phpunit/phpunit                    | 9.6.21    | 9.6.22   | [...](https://github.com/sebastianbergmann/phpunit/compare/9.6.21...9.6.22)              |
| psy/psysh                          | v0.12.4   | v0.12.7  | [...](https://github.com/bobthecow/psysh/compare/v0.12.4...v0.12.7)                      |
| sirbrillig/phpcs-variable-analysis | v2.11.19  | v2.11.21 | [...](https://github.com/sirbrillig/phpcs-variable-analysis/compare/v2.11.19...v2.11.21) |
| squizlabs/php_codesniffer          | 3.11.1    | 3.11.2   | [...](https://github.com/PHPCSStandards/PHP_CodeSniffer/compare/3.11.1...3.11.2)         |
| symfony/dependency-injection       | v6.4.15   | v6.4.16  | [...](https://github.com/symfony/dependency-injection/compare/v6.4.15...v6.4.16)         |
| symfony/deprecation-contracts      | v3.5.0    | v3.5.1   | [...](https://github.com/symfony/deprecation-contracts/compare/v3.5.0...v3.5.1)          |
| symfony/dom-crawler                | v6.4.13   | v6.4.16  | [...](https://github.com/symfony/dom-crawler/compare/v6.4.13...v6.4.16)                  |
| symfony/event-dispatcher-contracts | v3.5.0    | v3.5.1   | [...](https://github.com/symfony/event-dispatcher-contracts/compare/v3.5.0...v3.5.1)     |
| symfony/http-foundation            | v6.4.15   | v6.4.16  | [...](https://github.com/symfony/http-foundation/compare/v6.4.15...v6.4.16)              |
| symfony/http-kernel                | v6.4.15   | v6.4.16  | [...](https://github.com/symfony/http-kernel/compare/v6.4.15...v6.4.16)                  |
| symfony/phpunit-bridge             | v6.4.13   | v6.4.16  | [...](https://github.com/symfony/phpunit-bridge/compare/v6.4.13...v6.4.16)               |
| symfony/routing                    | v6.4.13   | v6.4.16  | [...](https://github.com/symfony/routing/compare/v6.4.13...v6.4.16)                      |
| symfony/service-contracts          | v3.5.0    | v3.5.1   | [...](https://github.com/symfony/service-contracts/compare/v3.5.0...v3.5.1)              |
| symfony/translation-contracts      | v3.5.0    | v3.5.1   | [...](https://github.com/symfony/translation-contracts/compare/v3.5.0...v3.5.1)          |
| symfony/validator                  | v6.4.15   | v6.4.16  | [...](https://github.com/symfony/validator/compare/v6.4.15...v6.4.16)                    |

