### PR TITLE
Prepare deployment 21-03-2025

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 All notable changes to this project will be documented in this file.
 <!--- END HEADER -->
 
+## [2.1.16](https://github.com/UN-OCHA/odsg8-site/compare/v2.1.15...v2.1.16) (2025-03-20)
+
+### Chores
+
+* Update all outdated drupal/* unocha/* drush/* weitzman/drupal-test-traits packages. ([9fdb1c](https://github.com/UN-OCHA/odsg8-site/commit/9fdb1c9f9e2cebaec8146e1ad4eff2a07f36cfdf))
+
 ## [2.1.15](https://github.com/UN-OCHA/odsg8-site/compare/v2.1.14...v2.1.15) (2025-03-19)
 
 ## [2.1.14](https://github.com/UN-OCHA/odsg8-site/compare/v2.1.13...v2.1.14) (2025-03-17)

--- a/composer.json
+++ b/composer.json
@@ -229,5 +229,5 @@
             "scripts\\composer\\DrupalLenientRequirement::changeVersionConstraint"
         ]
     },
-    "version": "2.1.15"
+    "version": "2.1.16"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ca0dfdbc49490c1d1ab2660ccb692255",
+    "content-hash": "2b235fc3ebaf939745efd91314291991",
     "packages": [
         {
             "name": "asm89/stack-cors",


### PR DESCRIPTION
## [2.1.16](https://github.com/UN-OCHA/odsg8-site/compare/v2.1.15...v2.1.16) (2025-03-20)

### Chores

* Update all outdated drupal/* unocha/* drush/* weitzman/drupal-test-traits packages. ([9fdb1c](https://github.com/UN-OCHA/odsg8-site/commit/9fdb1c9f9e2cebaec8146e1ad4eff2a07f36cfdf))